### PR TITLE
refactor: 설정 키보드 삭제, 화면 비율 조정

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,7 +8,7 @@ BLACK = (0, 0, 0)
 WHITE = (255, 255, 255)
 RED = (255, 0, 0)
 
-def main(screen_width = 1000, screen_height = 800):
+def main(screen_width = 800, screen_height = 600):
     pygame.init()
     
     # 화면 생성
@@ -16,7 +16,7 @@ def main(screen_width = 1000, screen_height = 800):
     pygame.display.set_caption("Uno Game")
 
     # 폰트 생성
-    font = pygame.font.SysFont("arial", screen_width // 20, True, True)
+    font = pygame.font.SysFont("arial", screen_width // 20, True)
 
     # 메뉴 텍스트 생성
     game_title = font.render("Uno Game", True, WHITE)
@@ -44,6 +44,7 @@ def main(screen_width = 1000, screen_height = 800):
     #메뉴 상수
     menu_flag = 0
     uno_game = Game(screen_width, screen_height, color_blind_mode=True)
+    set = setting.Setting(screen_width, screen_height)
     # 게임 루프
     play = True
     while play:
@@ -61,9 +62,7 @@ def main(screen_width = 1000, screen_height = 800):
                     if menu_flag == 0:
                         uno_game.run()
                     elif menu_flag == 1:
-                        set = setting.Setting
-                        set.start_setting(screen_width, screen_height)
-                        print("Settings")
+                        set.run(screen_width, screen_height)
                     elif menu_flag == 2:
                         
                         play = False
@@ -100,10 +99,7 @@ def main(screen_width = 1000, screen_height = 800):
         if single_player_rect.collidepoint(mouse_pos) and mouse_click[0]:
             uno_game.run()
         elif settings_rect.collidepoint(mouse_pos) and mouse_click[0]:
-            set = setting.Setting
-            set.start_setting(screen_width, screen_height)
-            print("Settings")
-
+            set.run(screen_width, screen_height)
         elif exit_rect.collidepoint(mouse_pos) and mouse_click[0]:
             play = False
 

--- a/setting.py
+++ b/setting.py
@@ -6,216 +6,190 @@ import time
 
 # Initialize Pygame
 class Setting():
-    def start_setting(screen_width, screen_height):
-        # Set the default size of the window
-        window_size = (screen_width, screen_height)
+    def __init__(self, screen_width, screen_height):
+         # Set the default size of the window
+        self.window_size = (screen_width, screen_height)
         # Create the window
-        screen = pygame.display.set_mode(window_size)
+        self.screen = pygame.display.set_mode(self.window_size)
         # Set the title of the window
-        pygame.display.set_caption("Resizable window")
         SAVE_DATA = shelve.open("Save Data")
     
+        self.running = True
 
         pygame.init()
         # Set the font for the buttons
-        font = pygame.font.SysFont("arial", screen_width//20, True, True)
-        screen_sizes_font = pygame.font.SysFont("arial", screen_width//40, True, True)
-        # Set the text color
-        text_color = 'white'
+        self.font = pygame.font.SysFont("arial", screen_width // 20, True)
+        self.screen_sizes_font = pygame.font.SysFont("arial", screen_width // 40, True)
         
         # Set the button sizes
-        screen_sizes = [(800, 600), (1024, 768), (1280, 720), (1920, 1080)]
-
-
+        self.screen_sizes = [(400, 300), (600, 450), (800, 600), (1000, 750)]
 
         ##게임제목
-        game_title = font.render("Uno Game", True, 'white')
-        game_title_rect = game_title.get_rect()
-        game_title_rect.centerx = screen.get_rect().centerx
-        game_title_rect.y = screen.get_size()[1] // 12
-        
+        self.game_title = self.font.render("Settings", True, 'white')
+        self.game_title_rect = self.game_title.get_rect()
+    
+        # Create the buttons
+        self.blind_text_surface = self.font.render("Color Blind Mode",True, 'white')
+        self.blind_text_rect = self.blind_text_surface.get_rect()
+    
+        # Create the buttons
+        self.default_text_surface = self.font.render("Default Setting",True, 'white')
+        self.default_text_rect = self.default_text_surface.get_rect()
         
         # Create the buttons
-        blind_text_surface = font.render("Color Blind Mode",True, text_color)
-        blind_text_rect = blind_text_surface.get_rect()
-        blind_text_rect.centerx = screen.get_rect().centerx
-        blind_text_rect.y = screen.get_size()[1] // 2.4
+        self.back_text_surface = self.font.render("Go Back",True, 'white')
+        self.back_text_rect = self.back_text_surface.get_rect()
+        
+        # Create the buttons
+        self.size1_text_surface = self.screen_sizes_font.render("size1",True, 'white')
+        self.size1_text_rect = self.size1_text_surface.get_rect()       
+        
+        # Create the buttons
+        self.size2_text_surface = self.screen_sizes_font.render("size2",True, 'white')
+        self.size2_text_rect = self.size2_text_surface.get_rect()       
+        
+        # Create the buttons
+        self.size3_text_surface = self.screen_sizes_font.render("size3",True, 'white')
+        self.size3_text_rect = self.size3_text_surface.get_rect()        
+        
+        # Create the buttons
+        self.size4_text_surface = self.screen_sizes_font.render("size4",True, 'white')
+        self.size4_text_rect = self.size4_text_surface.get_rect()
 
-        # Create the buttons
-        default_text_surface = font.render("Default Setting",True, text_color)
-        default_text_rect = default_text_surface.get_rect()
-        default_text_rect.centerx = screen.get_rect().centerx
-        default_text_rect.y = screen.get_size()[1] / 1.714
+        self.reposition(self.screen)
+    
+    def run(self, screen_width, screen_height):
 
-        # Create the buttons
-        back_text_surface = font.render("Go Back",True, text_color)
-        back_text_rect = back_text_surface.get_rect()
-        back_text_rect.centerx = screen.get_rect().centerx
-        back_text_rect.y = screen.get_size()[1] / 1.333 
+        window_size = (screen_width, screen_height)
+        self.screen = pygame.display.set_mode(window_size)
 
-        # Create the buttons
-        size1_text_surface = screen_sizes_font.render("size1",True, text_color)
-        size1_text_rect = size1_text_surface.get_rect()
-        size1_text_rect.centerx = screen.get_rect().centerx
-        size1_text_rect.x = screen.get_size()[0] / 5
-        
-        # Create the buttons
-        size2_text_surface = screen_sizes_font.render("size2",True, text_color)
-        size2_text_rect = size2_text_surface.get_rect()
-        size2_text_rect.centerx = screen.get_rect().centerx
-        size2_text_rect.x = screen.get_size()[0] / 2.5
-        
-        
-        # Create the buttons
-        size3_text_surface = screen_sizes_font.render("size3",True, text_color)
-        size3_text_rect = size3_text_surface.get_rect()
-        size3_text_rect.centerx = screen.get_rect().centerx
-        size3_text_rect.x = screen.get_size()[0] / 1.6666 
-        
-        
-        
-        # Create the buttons
-        size4_text_surface = screen_sizes_font.render("size4",True, text_color)
-        size4_text_rect = size4_text_surface.get_rect()
-        size4_text_rect.centerx = screen.get_rect().centerx
-        size4_text_rect.x = screen.get_size()[0] / 1.25 
-        
-        
-        # for i, label in enumerate(text_label):
-        #     text_surface = font.render(label, True, text_color)
-        #     text_rect = text_surface.get_rect()
-        #     # (40 + i * 100, 50, 80, 20)
-        #     text_rect.centerx = screen.get_rect().centerx
-        #     text_rect.x = screen.get_size()[0] // (5-i)
-        #     buttons.append((text_surface, screen_sizes[i],text_rect,text_rect.x))
-            
-        
-        #메뉴 상수
-        menu_flag = 0
-
-        # Game loop
-        running = True
-        while running:
+        while self.running:
+            pygame.init()
 
             for event in pygame.event.get():
                 if event.type == pygame.QUIT:
-                    running = False
-                if event.type == pygame.KEYDOWN:
-                    if event.key == pygame.K_UP:
-                        menu_flag -= 1
-                    elif event.key == pygame.K_DOWN:
-                        menu_flag += 1
-                    elif event.key == 13:
-                        if menu_flag == 0:
-                            print("Color blind mode")
-                        elif menu_flag == 1:
-                            print("Default mode")
-                        elif menu_flag == 2:
-                            main.main()
-                            print("Go Back")
-                        elif menu_flag == 3:
-                            window_size = screen_sizes[0]
-                            screen = pygame.display.set_mode(window_size)
-                            print("size1")
-                        elif menu_flag == 4:
-                            window_size = screen_sizes[1]
-                            screen = pygame.display.set_mode(window_size)
-                            print("size2")
-                        elif menu_flag == 5:
-                            window_size = screen_sizes[2]
-                            screen = pygame.display.set_mode(window_size)
-                            print("size3")
-                        elif menu_flag == 6:
-                            window_size = screen_sizes[3]
-                            screen = pygame.display.set_mode(window_size)
-                            print("size4") 
-                menu_flag %= 7
+                    self.running = False
                 
-
-
-            screen.fill('black')
+            self.screen.fill('black')
             # 제목 또는 버튼 출력
-            screen.blit(game_title, game_title_rect)
-            screen.blit(blind_text_surface, blind_text_rect)
-            screen.blit(default_text_surface, default_text_rect)
-            screen.blit(back_text_surface, back_text_rect)
-            screen.blit(size1_text_surface,size1_text_rect)
-            screen.blit(size2_text_surface,size2_text_rect)
-            screen.blit(size3_text_surface,size3_text_rect)
-            screen.blit(size4_text_surface,size4_text_rect)
+            self.screen.blit(self.game_title, self.game_title_rect)
+            self.screen.blit(self.blind_text_surface, self.blind_text_rect)
+            self.screen.blit(self.default_text_surface, self.default_text_rect)
+            self.screen.blit(self.back_text_surface, self.back_text_rect)
+            self.screen.blit(self.size1_text_surface,self.size1_text_rect)
+            self.screen.blit(self.size2_text_surface,self.size2_text_rect)
+            self.screen.blit(self.size3_text_surface,self.size3_text_rect)
+            self.screen.blit(self.size4_text_surface,self.size4_text_rect)
             
-
             mouse_pos = pygame.mouse.get_pos()
             mouse_click = pygame.mouse.get_pressed()
 
+            ## 색깔 변화. 
+            if self.blind_text_rect.collidepoint(mouse_pos):
+                self.blind_text_surface = self.font.render("Color Blind Mode", True, "red")
+            else: self.blind_text_surface = self.font.render("Color Blind Mode", True, "white")
 
-            # 버튼 출력과     올려놓거나 키보드 방향키 이동으로 색깔 변화. 
+            if self.default_text_rect.collidepoint(mouse_pos):
+                self.default_text_surface = self.font.render("Default Setting", True, "red")
+            else: self.default_text_surface = self.font.render("Default Setting", True, "white")
+
+            if self.back_text_rect.collidepoint(mouse_pos):
+                self.back_text_surface = self.font.render("Go Back", True, "red")
+            else: self.back_text_surface = self.font.render("Go Back", True, "white")
+
+            if self.size1_text_rect.collidepoint(mouse_pos):
+                self.size1_text_surface = self.screen_sizes_font.render("size1", True, "red")
+            else: self.size1_text_surface = self.screen_sizes_font.render("size1", True, "white")
+
+            if self.size2_text_rect.collidepoint(mouse_pos):
+                self.size2_text_surface = self.screen_sizes_font.render("size2", True, "red")
+            else: self.size2_text_surface = self.screen_sizes_font.render("size2", True, "white")
             
+            if self.size3_text_rect.collidepoint(mouse_pos):
+                self.size3_text_surface = self.screen_sizes_font.render("size3", True, "red")
+            else: self.size3_text_surface = self.screen_sizes_font.render("size3", True, "white")
             
-            
-            # for i, (text_surface, _, text_rect, text_rect.x) in enumerate(buttons):
-            #     screen.blit(text_surface,text_rect)
-            #     if text_rect.collidepoint(mouse_pos) or menu_flag == (i+3):
-            #         text_surface = font.render(text_label[i], True, "red")
-            #     else: text_surface = font.render(text_label[i], True, "white")
-                
-
-            ## 올려놓거나 키보드 방향키 이동으로 색깔 변화. 
-            if blind_text_rect.collidepoint(mouse_pos) or menu_flag == 0:
-                blind_text_surface = font.render("Color Blind Mode", True, "red")
-            else: blind_text_surface = font.render("Color Blind Mode", True, "white")
-
-            if default_text_rect.collidepoint(mouse_pos) or menu_flag == 1:
-                default_text_surface = font.render("Default Setting", True, "red")
-            else: default_text_surface = font.render("Default Setting", True, "white")
-
-            if back_text_rect.collidepoint(mouse_pos) or menu_flag == 2:
-                back_text_surface = font.render("Go Back", True, "red")
-            else: back_text_surface = font.render("Go Back", True, "white")
-
-            if size1_text_rect.collidepoint(mouse_pos) or menu_flag == 3:
-                size1_text_surface = screen_sizes_font.render("size1", True, "red")
-            else: size1_text_surface = screen_sizes_font.render("size1", True, "white")
-
-            if size2_text_rect.collidepoint(mouse_pos) or menu_flag == 4:
-                size2_text_surface = screen_sizes_font.render("size2", True, "red")
-            else: size2_text_surface = screen_sizes_font.render("size2", True, "white")
-            
-            if size3_text_rect.collidepoint(mouse_pos) or menu_flag == 5:
-                size3_text_surface = screen_sizes_font.render("size3", True, "red")
-            else: size3_text_surface = screen_sizes_font.render("size3", True, "white")
-            
-            if size4_text_rect.collidepoint(mouse_pos) or menu_flag == 6:
-                size4_text_surface = screen_sizes_font.render("size4", True, "red")
-            else: size4_text_surface = screen_sizes_font.render("size4", True, "white")
-
-
+            if self.size4_text_rect.collidepoint(mouse_pos):
+                self.size4_text_surface = self.screen_sizes_font.render("size4", True, "red")
+            else: self.size4_text_surface = self.screen_sizes_font.render("size4", True, "white")
 
              # 마우스 클릭 시
-            if  blind_text_rect.collidepoint(mouse_pos) and mouse_click[0]:
+            if  self.blind_text_rect.collidepoint(mouse_pos) and mouse_click[0]:
                 print("color_blind mode")
-            elif default_text_rect.collidepoint(mouse_pos) and mouse_click[0]:
-                window_size = (1000, 800)
+            elif self.default_text_rect.collidepoint(mouse_pos) and mouse_click[0]:
+                window_size = (800, 600)
                 screen = pygame.display.set_mode(window_size)
-                print("Default Setting")
-            elif back_text_rect.collidepoint(mouse_pos) and mouse_click[0]:
+                self.reposition(screen)
+            elif self.back_text_rect.collidepoint(mouse_pos) and mouse_click[0]:
                 time.sleep(0.15)
-                main.main()
-                print("Go Back")
-            elif size1_text_rect.collidepoint(mouse_pos) and mouse_click[0]:
-                    window_size = screen_sizes[0]
-                    screen = pygame.display.set_mode(window_size)
-            elif size2_text_rect.collidepoint(mouse_pos) and mouse_click[0]:
-                    window_size = screen_sizes[1]
-                    screen = pygame.display.set_mode(window_size)
-            elif size3_text_rect.collidepoint(mouse_pos) and mouse_click[0]:
-                    window_size = screen_sizes[2]
-                    screen = pygame.display.set_mode(window_size)
-            elif size4_text_rect.collidepoint(mouse_pos) and mouse_click[0]:
-                    window_size = screen_sizes[3]
-                    screen = pygame.display.set_mode(window_size)
+                main.main(window_size[0], window_size[1])
+            elif self.size1_text_rect.collidepoint(mouse_pos) and mouse_click[0]:
+                window_size = self.screen_sizes[0]
+                screen = pygame.display.set_mode(window_size)
+                self.reposition(screen)
+            elif self.size2_text_rect.collidepoint(mouse_pos) and mouse_click[0]:
+                window_size = self.screen_sizes[1]
+                screen = pygame.display.set_mode(window_size)
+                self.reposition(screen)
+            elif self.size3_text_rect.collidepoint(mouse_pos) and mouse_click[0]:
+                window_size = self.screen_sizes[2]
+                screen = pygame.display.set_mode(window_size)
+                self.reposition(screen)
+            elif self.size4_text_rect.collidepoint(mouse_pos) and mouse_click[0]:
+                window_size = self.screen_sizes[3]
+                screen = pygame.display.set_mode(window_size)
+                self.reposition(screen)
  
         # Update the display
             pygame.display.update()
         # Quit Pygame
-        pygame.quit() 
+        pygame.quit()
+            
+
+    def reposition(self, screen):
+        self.font = pygame.font.SysFont("arial", screen.get_size()[0]//20, True)
+        self.screen_sizes_font = pygame.font.SysFont("arial", screen.get_size()[0]//40, True)
+
+        self.game_title = self.font.render("Settings", True, 'white')
+        self.game_title_rect = self.game_title.get_rect()
+        self.game_title_rect.centerx = screen.get_rect().centerx
+        self.game_title_rect.y = screen.get_size()[1] / 12
+
+        self.blind_text_surface = self.font.render("Color Blind Mode",True, 'white')
+        self.blind_text_rect = self.blind_text_surface.get_rect()
+        self.blind_text_rect.centerx = screen.get_rect().centerx
+        self.blind_text_rect.y = screen.get_size()[1] / 2.4
+
+        self.default_text_surface = self.font.render("Default Setting",True, 'white')
+        self.default_text_rect = self.default_text_surface.get_rect()
+        self.default_text_rect.centerx = screen.get_rect().centerx
+        self.default_text_rect.y = screen.get_size()[1] / 1.714
+
+        self.back_text_surface = self.font.render("Go Back",True, 'white')
+        self.back_text_rect = self.back_text_surface.get_rect()
+        self.back_text_rect.centerx = screen.get_rect().centerx
+        self.back_text_rect.y = screen.get_size()[1] / 1.333
+
+        self.size1_text_surface = self.screen_sizes_font.render("size1",True, 'white')
+        self.size1_text_rect = self.size1_text_surface.get_rect() 
+        self.size1_text_rect.centerx = screen.get_rect().centerx
+        self.size1_text_rect.x = screen.get_size()[0] / 5
+        self.size1_text_rect.y = screen.get_size()[1] / 4
+
+        self.size2_text_surface = self.screen_sizes_font.render("size2",True, 'white')
+        self.size2_text_rect = self.size2_text_surface.get_rect() 
+        self.size2_text_rect.centerx = screen.get_rect().centerx
+        self.size2_text_rect.x = screen.get_size()[0] / 2.5
+        self.size2_text_rect.y = screen.get_size()[1] / 4
+
+        self.size3_text_surface = self.screen_sizes_font.render("size3",True, 'white')
+        self.size3_text_rect = self.size3_text_surface.get_rect()  
+        self.size3_text_rect.centerx = screen.get_rect().centerx
+        self.size3_text_rect.x = screen.get_size()[0] / 1.6666
+        self.size3_text_rect.y = screen.get_size()[1] / 4
+
+        self.size4_text_surface = self.screen_sizes_font.render("size4",True, 'white')
+        self.size4_text_rect = self.size4_text_surface.get_rect()
+        self.size4_text_rect.centerx = screen.get_rect().centerx
+        self.size4_text_rect.x = screen.get_size()[0] / 1.25
+        self.size4_text_rect.y = screen.get_size()[1] / 4


### PR DESCRIPTION
설정에서 화면 비율이 줄어드는 건 다 조정을 했는데, 아직 카드 객체에 있는 부분들이 숫자로 그대로 있어서 바꾸지는 못해서 게임 들어갔을 때 카드만 크기가 조절이 안되는 버그가 있고, 또 설정한 다음 메뉴 들어가서 다시 설정으로 들어가면 크기가 default로 재조정 되는 부분이 있는데 이 점도 다시 고쳐야 될 꺼 같아.
그리고 화면을 조정한 다음 게임을 실행시켰을 때 카드의 크기가 그대로 여서 카드가 겹치는 현상이 있었는데 오히려 이렇게 겹치면 카드의 수를 많이 둘 수 있어서 좋을지도...?  그래서 카드를 겹치게 gameUI파일에서 deck_spacing 변수를 음수 값으로 둬서 겹치게 두는 것도 좋을 거 같은데 내일 한번 이야기 해보면 좋을 거 같아.